### PR TITLE
Add QR code authentication as alternative login method

### DIFF
--- a/telegram-telethon/pyproject.toml
+++ b/telegram-telethon/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "questionary>=2.0",      # Interactive prompts
     "aiofiles>=23.0",        # Async file I/O
     "httpx>=0.27.0",         # Groq API for transcription
+    "qrcode>=7.0",          # QR code login display
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

Adds QR code login as an alternative authentication method when phone verification codes don't arrive.

**Problem solved:** During setup, verification codes sometimes don't arrive on either the Telegram app or via SMS. This can block users from completing authentication entirely. (Encountered by me personally)

**Solution:** QR code authentication works instantly by scanning with Telegram mobile app (Settings → Devices → Link Desktop Device), bypassing the phone verification flow completely.

## Changes

- **auth.py**: Added `start_qr_login()` and `wait_for_qr_login()` methods to `AuthWizard` class
- **tg.py**: Added `--qr` CLI flag and `setup_qr()` function with terminal QR code display
- **pyproject.toml**: Added `qrcode>=7.0` dependency

## Usage

```bash
# Use QR code instead of phone verification
python3 scripts/tg.py setup --qr

# Or with pre-provided credentials
python3 scripts/tg.py setup --api-id 12345 --api-hash abc123 --qr
```

## Testing

- Tested QR code generation and display in terminal
- Verified successful authentication via QR scan
- Confirmed existing phone-based auth still works unchanged

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)