### PR TITLE
fix: output UTF-8 Cyrillic instead of Unicode escapes in JSON

### DIFF
--- a/telegram-telethon/scripts/tg.py
+++ b/telegram-telethon/scripts/tg.py
@@ -296,7 +296,7 @@ async def cmd_recent(args):
 
         if args.output:
             result = save_to_file(messages, args.output, output_fmt)
-            print(json.dumps(result, indent=2))
+            print(json.dumps(result, indent=2, ensure_ascii=False))
         elif args.to_daily:
             path = append_to_daily(format_output(messages, output_fmt))
             print(f"Appended to {path}")
@@ -324,7 +324,7 @@ async def cmd_search(args):
 
         if args.output:
             result = save_to_file(messages, args.output, output_fmt)
-            print(json.dumps(result, indent=2))
+            print(json.dumps(result, indent=2, ensure_ascii=False))
         elif args.to_daily:
             path = append_to_daily(format_output(messages, output_fmt))
             print(f"Appended to {path}")
@@ -365,7 +365,7 @@ async def cmd_thread(args):
 
         if args.output:
             result = save_to_file(messages, args.output, output_fmt)
-            print(json.dumps(result, indent=2))
+            print(json.dumps(result, indent=2, ensure_ascii=False))
         else:
             print(format_output(messages, output_fmt))
     finally:
@@ -386,7 +386,7 @@ async def cmd_send(args):
             client, chat_name=args.chat, text=args.text or "",
             reply_to=reply_to, file_path=args.file, allowed_groups=allowed_groups,
         )
-        print(json.dumps(result, indent=2))
+        print(json.dumps(result, indent=2, ensure_ascii=False))
     finally:
         await client.disconnect()
 
@@ -401,7 +401,7 @@ async def cmd_delete(args):
             client, chat_name=args.chat, message_ids=args.message_ids,
             revoke=not args.no_revoke,
         )
-        print(json.dumps(result, indent=2))
+        print(json.dumps(result, indent=2, ensure_ascii=False))
     finally:
         await client.disconnect()
 
@@ -416,7 +416,7 @@ async def cmd_forward(args):
             client, from_chat=args.from_chat, to_chat=args.to_chat,
             message_ids=args.message_ids,
         )
-        print(json.dumps(result, indent=2))
+        print(json.dumps(result, indent=2, ensure_ascii=False))
     finally:
         await client.disconnect()
 
@@ -428,7 +428,7 @@ async def cmd_mark_read(args):
     client = await get_client()
     try:
         result = await mark_read(client, chat_name=args.chat, max_id=args.max_id)
-        print(json.dumps(result, indent=2))
+        print(json.dumps(result, indent=2, ensure_ascii=False))
     finally:
         await client.disconnect()
 
@@ -440,7 +440,7 @@ async def cmd_edit(args):
     client = await get_client()
     try:
         result = await edit_message(client, chat_name=args.chat, message_id=args.message_id, text=args.text)
-        print(json.dumps(result, indent=2))
+        print(json.dumps(result, indent=2, ensure_ascii=False))
     finally:
         await client.disconnect()
 


### PR DESCRIPTION
## Problem

Python's `json.dumps()` escapes non-ASCII characters by default, outputting Unicode escape sequences instead of actual UTF-8 characters. This causes:

1. **Increased token usage** - each Cyrillic char becomes 6 characters (`\u0430` vs `а`)
2. **Poor readability** - hard to read in logs and debugging

### Before (escaped)
```json
{
  "saved": true,
  "chat": "\u0410\u043d\u044f \u041a\u0443\u0437\u043d\u0435\u0446\u043e\u0432\u0430",
  "text_preview": "\u0443\u0434\u0430\u0447\u0438 \u0441 \u043e\u0433\u0443\u0440\u0447\u0438\u043a\u0430\u043c\u0438!"
}
```

### After (UTF-8)
```json
{
  "saved": true,
  "chat": "Аня Кузнецова",
  "text_preview": "удачи с огурчиками!"
}
```

## Solution

Add `ensure_ascii=False` to all `json.dumps()` calls in `tg.py` (8 occurrences).

🤖 Generated with [Claude Code](https://claude.ai/code)