### PR TITLE
Add SkillCheck badges to fathom skill

### DIFF
--- a/fathom/README.md
+++ b/fathom/README.md
@@ -1,0 +1,5 @@
+![SkillCheck Passed](badges/passed.svg) ![WCAG AA](badges/wcag-aa.svg) ![Anti-Slop 90](badges/antislop-90.svg)
+
+# fathom
+
+See [SKILL.md](SKILL.md) for skill definition.

--- a/fathom/badges/antislop-90.svg
+++ b/fathom/badges/antislop-90.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="174" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="round">
+    <rect width="174" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#round)">
+    <rect width="80" height="20" fill="#555"/>
+    <rect x="80" width="94" height="20" fill="#ff9800"/>
+    <rect width="174" height="20" fill="url(#smooth)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="40" y="15" fill="#010101" fill-opacity=".3">skillcheck</text>
+    <text x="40" y="14">skillcheck</text>
+    <text x="127" y="15" fill="#010101" fill-opacity=".3">antislop 100</text>
+    <text x="127" y="14">antislop 100</text>
+  </g>
+</svg>

--- a/fathom/badges/enterprise.svg
+++ b/fathom/badges/enterprise.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="round">
+    <rect width="160" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#round)">
+    <rect width="80" height="20" fill="#555"/>
+    <rect x="80" width="80" height="20" fill="#9c27b0"/>
+    <rect width="160" height="20" fill="url(#smooth)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="40" y="15" fill="#010101" fill-opacity=".3">skillcheck</text>
+    <text x="40" y="14">skillcheck</text>
+    <text x="120" y="15" fill="#010101" fill-opacity=".3">enterprise</text>
+    <text x="120" y="14">enterprise</text>
+  </g>
+</svg>

--- a/fathom/badges/marketplace.svg
+++ b/fathom/badges/marketplace.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="118" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="round">
+    <rect width="118" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#round)">
+    <rect width="80" height="20" fill="#555"/>
+    <rect x="80" width="38" height="20" fill="#ffd700"/>
+    <rect width="118" height="20" fill="url(#smooth)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="40" y="15" fill="#010101" fill-opacity=".3">skillcheck</text>
+    <text x="40" y="14">skillcheck</text>
+    <text x="99" y="15" fill="#010101" fill-opacity=".3">gold</text>
+    <text x="99" y="14">gold</text>
+  </g>
+</svg>

--- a/fathom/badges/passed.svg
+++ b/fathom/badges/passed.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="132" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="round">
+    <rect width="132" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#round)">
+    <rect width="80" height="20" fill="#555"/>
+    <rect x="80" width="52" height="20" fill="#4c1"/>
+    <rect width="132" height="20" fill="url(#smooth)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="40" y="15" fill="#010101" fill-opacity=".3">skillcheck</text>
+    <text x="40" y="14">skillcheck</text>
+    <text x="106" y="15" fill="#010101" fill-opacity=".3">passed</text>
+    <text x="106" y="14">passed</text>
+  </g>
+</svg>

--- a/fathom/badges/wcag-aa.svg
+++ b/fathom/badges/wcag-aa.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="139" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="round">
+    <rect width="139" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#round)">
+    <rect width="80" height="20" fill="#555"/>
+    <rect x="80" width="59" height="20" fill="#2196f3"/>
+    <rect width="139" height="20" fill="url(#smooth)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="40" y="15" fill="#010101" fill-opacity=".3">skillcheck</text>
+    <text x="40" y="14">skillcheck</text>
+    <text x="109" y="15" fill="#010101" fill-opacity=".3">WCAG AA</text>
+    <text x="109" y="14">WCAG AA</text>
+  </g>
+</svg>

--- a/fathom/badges/wcag-aaa.svg
+++ b/fathom/badges/wcag-aaa.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="146" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="round">
+    <rect width="146" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#round)">
+    <rect width="80" height="20" fill="#555"/>
+    <rect x="80" width="66" height="20" fill="#ffd700"/>
+    <rect width="146" height="20" fill="url(#smooth)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="40" y="15" fill="#010101" fill-opacity=".3">skillcheck</text>
+    <text x="40" y="14">skillcheck</text>
+    <text x="113" y="15" fill="#010101" fill-opacity=".3">WCAG AAA</text>
+    <text x="113" y="14">WCAG AAA</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

This PR adds SkillCheck validation badges to the **fathom** skill.

### Badges Earned

| Badge | Description |
|-------|-------------|
| ![passed](badges/passed.svg) | Passed SkillCheck validation |
| ![wcag-aa](badges/wcag-aa.svg) | WCAG AA accessibility compliant |
| ![antislop-90](badges/antislop-90.svg) | Anti-slop score ≥90% |

### What is SkillCheck?

[SkillCheck](https://github.com/olgasafonova/SkillCheck) validates Claude Code skills against:
- [agentskills specification](https://github.com/agentskills/agentskills)
- MCP best practices
- WCAG accessibility standards

### Changes

- Added `badges/` folder with SVG badge files
- Created `README.md` with badge display

---

🤖 Generated with [SkillCheck](https://github.com/olgasafonova/SkillCheck) v2.0.0