### PR TITLE
agency-docs: workflow analysis + aggregation rebuild + fan-out maintenance workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,8 @@ End-to-end pipeline for publishing Claude Code lab meetings. Single `/agency-doc
 - 📊 Lesson HTML copied to public/ and linked in meeting page
 - ✅ Local build verification + Vercel deployment check
 - 🔢 Auto-detect or specify meeting number
+- 📚 Rebuilds site-wide aggregations after each meeting — meetings index/database, glossary, and global link library (`scripts/rebuild_aggregations.py`)
+- 🛠️ Fan-out maintenance workflows for repo-wide MDX/embed audits and backfill/repair of past meetings (`references/workflows.md`)
 
 **Quick Start:**
 ```bash

--- a/agency-docs-updater/SKILL.md
+++ b/agency-docs-updater/SKILL.md
@@ -240,6 +240,35 @@ Run with `run_in_background: true`. If state is `failure` or `error`: check Verc
 
 Open `https://${SITE_DOMAIN}/claude-code-lab-${LAB_NUMBER}/meetings/${MEETING_NUMBER}` in a browser (via chrome automation tools or manually). Verify YouTube embed is visible. If not: check VIDEO_ID, wait for YouTube processing, or re-upload.
 
+## Step 9: Rebuild Site-Wide Aggregations
+
+After the new meeting is committed (Step 6), regenerate the three site-wide aggregations from **all** meetings so the new one is reflected: the **database** (meetings index), the **glossary**, and the **global library** of links.
+
+```bash
+python3 ${SKILLS_LOCAL_DIR}/agency-docs-updater/scripts/rebuild_aggregations.py
+```
+
+The script reads the same `.env` paths and writes (paths configurable via `AGG_*` env vars):
+- `content/docs/database.mdx` + `public/data/meetings.json` — index of every meeting
+- `content/docs/glossary.mdx` (definitions persisted in `.agency-glossary.json`)
+- `content/docs/library.mdx` — deduplicated external links across all meetings
+
+**Handle new glossary terms**: the script prints `→ N NEW term(s) need definitions` for terms it has never seen. For each, write a one-line definition into `${DOCS_SITE_DIR}/.agency-glossary.json` (keep technical terms in English; match the page language otherwise), then re-run the script so the glossary MDX regenerates with the definitions. Leave already-defined terms untouched — the store is the source of truth.
+
+**Then**: `cd ${DOCS_SITE_DIR} && npm run build 2>&1 | tail -5` to confirm the generated MDX compiles, stage the changed aggregation files (the three MDX pages, `public/data/meetings.json`, and `.agency-glossary.json` — never `git add .`), and commit:
+```bash
+git add content/docs/database.mdx content/docs/glossary.mdx content/docs/library.mdx \
+        public/data/meetings.json .agency-glossary.json
+git commit -m "Rebuild aggregations after Lab ${LAB_NUMBER} Meeting ${MEETING_NUMBER}"
+git push
+```
+
+This commit can be folded into Step 6's commit if you prefer a single push; either way it must land before re-running Step 7's deploy wait.
+
 ## Pipeline Report
 
-After completion, report: Fathom path, video path, YouTube URL, MDX path, commit hash, deploy status, embed verification.
+After completion, report: Fathom path, video path, YouTube URL, MDX path, commit hash, deploy status, embed verification, and the aggregation rebuild (meeting count, any new glossary terms defined).
+
+## Related: fan-out maintenance workflows
+
+For **repo-wide** jobs across all past meetings — auditing every page for broken embeds/MDX defects, or backfilling/repairing incomplete meetings — see `references/workflows.md`. Those are fan-out [dynamic workflows](https://code.claude.com/docs/en/workflows.md) (one agent per meeting), run on demand, separate from this single-meeting pipeline.

--- a/agency-docs-updater/references/learnings.md
+++ b/agency-docs-updater/references/learnings.md
@@ -31,3 +31,11 @@
 ## Git push
 - Only stage pipeline-created files — never `git add .`
 - If remote is ahead: `git stash push`, `git pull --rebase`, push, `git stash pop`
+
+## Aggregations (Step 9)
+- `rebuild_aggregations.py` regenerates database/glossary/library from ALL meetings — it's idempotent, safe to re-run
+- Glossary definitions live in `.agency-glossary.json`, NOT in the generated MDX — edit the store, then re-run. Definitions survive rebuilds; only genuinely new terms are flagged
+- Generated MDX pages carry a `{/* GENERATED ... */}` banner — don't hand-edit them
+- The acronym extractor strips URLs first so referral codes (e.g. `…/r/GLEB3`) aren't mistaken for terms; still skim the NEW-term list for noise before defining
+- Per-meeting Fathom/YouTube links are intentionally excluded from the library (they're in the database) — the library is for external resources only
+- Always `npm run build` after a rebuild — the generated MDX can break the deploy just like meeting MDX can

--- a/agency-docs-updater/references/workflow-conversion-analysis.md
+++ b/agency-docs-updater/references/workflow-conversion-analysis.md
@@ -1,0 +1,138 @@
+# Should `agency-docs-updater` become a dynamic Workflow?
+
+**Recommendation: No — keep it a Skill.** This pipeline is close to the textbook
+anti-fit for a [dynamic workflow](https://code.claude.com/docs/en/workflows.md). The
+parts of the workflow feature that justify its cost (massive subagent fan-out, context
+offloading, a rerunnable orchestration with adversarial verification) don't apply here,
+while the parts that hurt (no mid-run sign-off, multi-agent token overhead, resume only
+within one session, research-preview status) hit exactly the places this pipeline is
+fragile.
+
+This doc records the reasoning so the question doesn't get re-litigated.
+
+---
+
+## What a Workflow actually is (Opus 4.8, research preview)
+
+Per the [official docs](https://code.claude.com/docs/en/workflows.md), a dynamic workflow
+is **a JavaScript script Claude writes that orchestrates subagents at scale**. The runtime
+executes it in the background; intermediate results live in script variables instead of
+Claude's context window. Triggered by the word `workflow` in a prompt, by `/effort
+ultracode`, or by running a saved/bundled command like `/deep-research`. Saved to
+`.claude/workflows/` (project) or `~/.claude/workflows/` (personal).
+
+The doc's own "when to use" guidance — *who holds the plan*:
+
+| | Subagents | Skills | Workflows |
+|---|---|---|---|
+| What it is | A worker Claude spawns | Instructions Claude follows | A script the runtime executes |
+| Who decides next | Claude, turn by turn | Claude, following the prompt | The script |
+| Intermediate results | Claude's context | Claude's context | Script variables |
+| What's repeatable | The worker definition | The instructions | The orchestration itself |
+| Scale | A few per turn | Same | **Dozens to hundreds of agents per run** |
+| Interruption | Restarts the turn | Restarts the turn | Resumable in the same session |
+
+> "Reach for a workflow when a task needs more agents than one conversation can
+> coordinate, or when you want the orchestration codified as a script you can read and
+> rerun." Canonical examples: a codebase-wide bug sweep, a 500-file migration,
+> cross-checked research, drafting a hard plan from several independent angles.
+
+The value is **fan-out + a repeatable quality pattern** (independent agents adversarially
+reviewing each other), not "running steps in order."
+
+---
+
+## Why this pipeline is a poor fit
+
+`agency-docs-updater` is a **linear, single-subject publishing pipeline**: 8 sequential
+steps, one lab meeting at a time, run ~weekly. Match it against what workflows are for:
+
+| Workflow earns its cost via… | …does `agency-docs-updater` have it? |
+|---|---|
+| Dozens–hundreds of parallel agents | **No.** One subject per run; at most a 2-way split (Step 3 upload ∥ Step 4 summary). |
+| Context-window pressure to offload | **No.** Intermediate state is a handful of paths/IDs (`VIDEO_ID`, `MEETING_NUMBER`, URLs) — tiny. |
+| Adversarial cross-checking across many passes | **Marginal.** Only Step 4's fact-check, which a single `claude-code-guide` subagent already covers. |
+| Orchestration worth codifying as a rerunnable script | **Already true.** The plan is already scripted — SKILL.md plus `update_meeting_doc.py`, `process_video.py`, `zoom_meetings.py`. |
+
+So the upside column is mostly empty. Now the downsides, which land on this pipeline's
+known-fragile spots (see `learnings.md`):
+
+1. **No mid-run user input.** The docs are explicit: *"Only agent permission prompts can
+   pause a run. For sign-off between stages, run each stage as its own workflow."* This
+   pipeline publishes to **public YouTube and a public Vercel site** and has documented
+   failure modes that need a human/operator's judgment to recover:
+   - videos that upload "successfully" then get silently deleted by YouTube (Step 3a exists
+     precisely for this),
+   - MDX that breaks the Vercel build (`<!-- -->`, bare `<`, `{`),
+   - ambiguous meeting-number detection (`-n NN` override),
+   - Vercel deploy failures (Step 7).
+   A skill lets the operator step in with judgment at any of these. A workflow can't pause
+   for sign-off — it can only block on a permission prompt.
+
+2. **Multi-agent token cost for no parallelism benefit.** Workflows pay for scale. With
+   ~no fan-out here, you'd take the orchestration overhead of spawned agents and get none
+   of the speedup that pays for it.
+
+3. **Resume is single-session only.** *"If you exit Claude Code while a workflow is
+   running, the next session starts the workflow fresh."* This pipeline has long unattended
+   waits — Zoom processing (~15 min), YouTube upload/processing (10–30 min), Vercel deploy.
+   The skill already survives these across sessions via **idempotent step-skipping**
+   (`--resume-from upload`, "skip if MP4 > 1MB exists", placeholder-MDX detection). A
+   workflow would lose that cross-session resilience.
+
+4. **The script can't touch the filesystem/shell directly** — *"Agents read, write, and
+   run commands. The script coordinates the agents."* Every bash/python call would route
+   through a spawned agent, adding indirection over today's direct execution.
+
+5. **Research preview.** Pinning a production publishing pipeline to a preview feature
+   (v2.1.154+, behavior may change) is avoidable risk for no offsetting gain.
+
+### Automation-advisor lens
+
+Scoring with the repo's own `automation-advisor` matrix — Frequency ~weekly (3), Time
+30–120+ min manual (4), Error cost annoying→high / public artifacts (3), Longevity years
+(5) → well above the "automate now" threshold. **It already is automated** — as a skill.
+The matrix says *automate*; it does **not** say *use the workflow primitive*. The override
+checks (high external-dependency variability + high error cost → keep a validation layer /
+human-in-loop) actively argue **against** the unattended, no-sign-off shape of a workflow.
+
+---
+
+## Where Workflows *would* pay off in this domain
+
+The single-meeting pipeline is the wrong target, but adjacent **fan-out** jobs are exactly
+what workflows are built for, and the skill doesn't cover them today:
+
+- **Backfill / bulk repair** — re-publish or fix every past lab meeting in one run (one
+  agent per meeting). Classic fan-out.
+- **Repo-wide MDX audit** — check every meeting MDX across all labs for broken YouTube
+  embeds, dead links, and MDX-compile hazards, with findings cross-checked. This is
+  literally the docs' "codebase-wide bug sweep" example.
+- **Bulk thumbnail regeneration** — re-render branded thumbnails across all past meetings.
+
+These earn the multi-agent cost; the weekly single-meeting publish does not.
+
+---
+
+## Bottom line
+
+| | Convert to Workflow | Keep as Skill (recommended) |
+|---|---|---|
+| Parallelism payoff | None — sequential pipeline | n/a |
+| Token cost | Higher (multi-agent overhead) | Lower |
+| Human sign-off at fragile steps | **Lost** (no mid-run input) | Preserved |
+| Cross-session resilience | Lost (resume = same session) | Preserved (idempotent skips) |
+| Maturity | Research preview | Stable |
+| Effort to migrate | Non-trivial rewrite | Zero |
+
+Keep `agency-docs-updater` as a Skill. If we want to use the workflow feature in this area,
+build a **separate** workflow for the batch/audit jobs above — don't reshape the
+publish-one-meeting pipeline into one.
+
+---
+
+*Sources: [Orchestrate subagents at scale with dynamic
+workflows](https://code.claude.com/docs/en/workflows.md) ·
+[Skills](https://code.claude.com/docs/en/skills.md) ·
+[Subagents](https://code.claude.com/docs/en/sub-agents.md) · this skill's `SKILL.md` and
+`references/learnings.md`.*

--- a/agency-docs-updater/references/workflows.md
+++ b/agency-docs-updater/references/workflows.md
@@ -1,0 +1,98 @@
+# Fan-out workflows for agency-docs
+
+Two jobs in this domain are a natural fit for the new [dynamic workflows](https://code.claude.com/docs/en/workflows.md)
+feature (Opus 4.8, research preview): the **repo-wide MDX/embed audit** and the
+**backfill/repair of past meetings**. Both fan out one agent per meeting, which is
+exactly what workflows are built for — and what the single-meeting publish pipeline is
+*not* (see `workflow-conversion-analysis.md`).
+
+## Why these are prompts, not committed `.js` files
+
+Dynamic workflows are created by *running* them: include the word `workflow` in a prompt,
+let Claude write and run the orchestration script, then press `s` in `/workflows` to save
+that run's script as a reusable `/command`. There is no published API for hand-authoring
+the runtime `.js`, so the correct, runnable deliverable is a precise **trigger prompt** you
+paste once. After the first good run, save it (`s` → `.claude/workflows/`) and it becomes
+`/agency-mdx-audit` / `/agency-backfill` in every future session.
+
+Run these **locally**, where `$DOCS_SITE_DIR` points at your agency-docs checkout. Before a
+long run, allowlist the shell commands the agents need (`npm`, `git`, `python3`, the
+YouTube/oEmbed checks) so they don't prompt mid-run.
+
+---
+
+## 1. MDX / embed audit  →  save as `/agency-mdx-audit`
+
+Paste this (the word *workflow* triggers it):
+
+> Run a **workflow** to audit every published lab meeting on the agency-docs site for
+> publishing defects. The meetings are MDX files at
+> `$DOCS_SITE_DIR/content/docs/claude-code-internal-*/meetings/NN.mdx` (NN = two digits).
+> Fan out **one agent per meeting file**. Each agent checks its file and reports findings;
+> do not fix anything. Check for:
+>
+> 1. **MDX compile hazards** (these break the Vercel build): HTML comments `<!-- -->`,
+>    unescaped `<` that isn't a known tag like `<iframe>`, and bare `{` / `}` outside code
+>    fences. (See `references/learnings.md`.)
+> 2. **Unfilled placeholders** left by the pipeline: `[Название встречи]`,
+>    `[Краткое описание встречи]`, `[Дата встречи]`.
+> 3. **YouTube embed health**: extract the video id from the `youtube.com/embed/<id>`
+>    iframe, then verify the video is live via the oEmbed endpoint
+>    `https://www.youtube.com/oembed?url=https://youtu.be/<id>&format=json` — a "Not Found"
+>    means the video was deleted/made private (a documented failure mode). Flag any meeting
+>    with a missing iframe or a dead id.
+> 4. **Dead external links**: HEAD/GET each external link in the body; flag non-2xx/3xx.
+> 5. **Missing pieces**: no Fathom link, no YouTube link, or an empty summary.
+>
+> Have a final agent **cross-check and dedupe** the findings, then return one grouped
+> report: per meeting (lab + number + path), the list of issues and a one-line suggested
+> fix for each. Order by severity (build-breakers first). No code changes.
+
+Once the report looks right, press `s` to save it as `/agency-mdx-audit`. Re-run it after
+big edits or before a release; feed its build-breaker findings into the backfill workflow.
+
+---
+
+## 2. Backfill / repair past meetings  →  save as `/agency-backfill`
+
+Run the audit first so this one has a worklist. Then paste:
+
+> Run a **workflow** to repair the lab meetings flagged by the audit. Input: the list of
+> `(lab, meeting number, issues)` from `/agency-mdx-audit` (or, if none given, re-derive it
+> by scanning `$DOCS_SITE_DIR/content/docs/claude-code-internal-*/meetings/NN.mdx` for the
+> same defects). Fan out **one agent per broken meeting**. Each agent fixes only its own
+> file and only the flagged issues:
+>
+> - **Unfilled placeholders** → derive the title/description/date from the meeting's own
+>   summary body and the YouTube metadata; fill them in. Keep the page's language
+>   consistent (don't mix RU/EN — see `references/learnings.md`).
+> - **MDX compile hazards** → escape/strip per the learnings (remove `<!-- -->`, escape bare
+>   `<` and `{`).
+> - **Dead/missing YouTube embed** → if the original `$VAULT_DIR/<video-name>.mp4` and the
+>   Fathom transcript still exist, re-run the relevant `agency-docs-updater` steps (Step 3
+>   re-upload + Step 3a verify + Step 4b metadata) and swap in the new id; otherwise leave
+>   a `TODO` note in the agent's report rather than inventing a link.
+> - **Dead external links** → mark them, don't guess replacements.
+>
+> Each agent must `cd $DOCS_SITE_DIR && npx mdx-bundler` or `npm run build` on its file's
+> path (or, cheaper, validate the single file compiles) before declaring success, since the
+> whole point is not to re-break the build. Agents touch **different files**, so no worktree
+> conflicts. Return a per-meeting report of what was changed and what still needs a human.
+>
+> Do **not** commit or push — leave the working tree dirty so I can review the diff, run
+> `npm run build`, and commit myself.
+
+Save as `/agency-backfill`. Keep commit/push manual: this writes to a public site, and a
+workflow can't pause for sign-off mid-run.
+
+---
+
+## Caveats (per the official docs)
+
+- **Research preview**, v2.1.154+. Turn on via `/config` (Pro) if needed.
+- **No mid-run user input** — only tool-permission prompts can pause. That's why both
+  workflows *report* (audit) or *leave the tree dirty* (backfill) instead of pushing.
+- **Cost**: many parallel agents use meaningfully more tokens than a conversational pass.
+  Consider routing the per-file agents to a smaller model when you describe the task.
+- **Limits**: up to 16 concurrent agents, 1,000 per run. Fine for dozens of meetings.
+- **Resume** works only within the same session; if you exit, the run starts fresh.

--- a/agency-docs-updater/scripts/rebuild_aggregations.py
+++ b/agency-docs-updater/scripts/rebuild_aggregations.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""
+Rebuild site-wide aggregations for the agency-docs site from every published
+lab meeting. Run after each meeting is published (Step 9 of the pipeline) or
+standalone to backfill.
+
+Produces three aggregations, each derived from ALL meeting MDX across ALL labs:
+
+  1. database  — a meetings index: one row per meeting (lab, number, date,
+     title, YouTube/Fathom links). Written as both an MDX page (human) and a
+     JSON file (machine / client-side search).
+  2. glossary  — technical terms seen across meetings, with definitions. Term
+     definitions are persisted in a JSON store so human/LLM-written wording
+     survives rebuilds; only NEW terms are reported for definition.
+  3. library   — a deduplicated "global library" of every external link
+     mentioned across all meetings, grouped by domain.
+
+DESIGN NOTE — this script is authored against the documented ${DOCS_SITE_DIR}
+conventions (see SKILL.md) without access to the live site, so every input and
+output path is configurable via .env / environment and the defaults are
+conservative. Run with --dry-run first to confirm the paths and counts before
+writing anything. Adjust the AGG_* env vars if your site lays things out
+differently.
+
+Reads path configuration from .env in the skill root, matching update_meeting_doc.py.
+"""
+
+import os
+import re
+import sys
+import json
+import argparse
+from pathlib import Path
+from datetime import datetime, timezone
+from urllib.parse import urlparse
+from collections import defaultdict
+
+
+# ---------------------------------------------------------------------------
+# Config (mirrors update_meeting_doc.py so both scripts read the same .env)
+# ---------------------------------------------------------------------------
+
+def load_env():
+    """Load .env file from skill root if it exists."""
+    env_file = Path(__file__).parent.parent / '.env'
+    if env_file.exists():
+        with open(env_file, 'r', encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith('#') and '=' in line:
+                    key, value = line.split('=', 1)
+                    value = os.path.expanduser(value.strip())
+                    os.environ.setdefault(key.strip(), value)
+
+
+def get_path(env_var: str, default_relative: str) -> Path:
+    value = os.environ.get(env_var)
+    if value:
+        return Path(os.path.expanduser(value))
+    return Path.home() / default_relative
+
+
+def docs_site_dir() -> Path:
+    return get_path('DOCS_SITE_DIR', 'Sites/agency-docs')
+
+
+def site_domain() -> str:
+    return os.environ.get('SITE_DOMAIN', 'agency-lab.glebkalinin.com')
+
+
+def out_path(env_var: str, default_rel_to_site: str) -> Path:
+    """Resolve an output path, defaulting to a location under the site dir."""
+    value = os.environ.get(env_var)
+    if value:
+        return Path(os.path.expanduser(value))
+    return docs_site_dir() / default_rel_to_site
+
+
+# Seed glossary: terms the lab uses constantly. Persisted-store definitions
+# (if present) always win over these; this is only a starting vocabulary so a
+# first run isn't empty.
+SEED_TERMS = {
+    "MCP": "Model Context Protocol — open standard for connecting Claude to external tools and data sources.",
+    "Skills": "Reusable instruction sets (SKILL.md) Claude Code invokes contextually to perform a procedure.",
+    "Claude Code": "Anthropic's agentic coding CLI/IDE assistant.",
+    "Subagents": "Worker Claude sessions spawned to handle a side task in their own context.",
+    "Workflows": "Dynamic workflows — a script that orchestrates many subagents at scale (Opus 4.8, research preview).",
+    "CLI": "Command-line interface.",
+    "SDK": "Software development kit.",
+    "MDX": "Markdown extended with JSX — the format the docs site is authored in.",
+    "RAG": "Retrieval-augmented generation.",
+    "LLM": "Large language model.",
+    "YOLO": "Running an agent with permissions bypassed (no per-action approval).",
+}
+
+# Known multi-word / branded terms to detect verbatim (case-insensitive match,
+# canonical casing preserved).
+KNOWN_PHRASES = [
+    "Claude Code", "Nano Banana", "vibe coding", "Agent SDK", "Model Context Protocol",
+]
+
+
+# ---------------------------------------------------------------------------
+# MDX helpers
+# ---------------------------------------------------------------------------
+
+def mdx_escape(text: str) -> str:
+    """Make a plain string safe to drop into MDX prose/table cells."""
+    if text is None:
+        return ""
+    # Escape MDX/JSX hazards documented in learnings.md: <, {, and HTML comments.
+    text = text.replace("<!--", "").replace("-->", "")
+    text = text.replace("<", "&lt;").replace(">", "&gt;")
+    text = text.replace("{", "&#123;").replace("}", "&#125;")
+    text = text.replace("|", "\\|")  # don't break table rows
+    return text.strip()
+
+
+def split_frontmatter(content: str):
+    """Return (frontmatter_dict, body_str). Tolerant of missing yaml module."""
+    parts = content.split('---')
+    if len(parts) < 3 or parts[0].strip():
+        return {}, content
+    fm_raw, body = parts[1].strip(), '---'.join(parts[2:])
+    fm = {}
+    try:
+        import yaml
+        fm = yaml.safe_load(fm_raw) or {}
+    except Exception:
+        for line in fm_raw.split('\n'):
+            if ':' in line:
+                k, v = line.split(':', 1)
+                fm[k.strip()] = v.strip().strip('"\'')
+    return fm, body
+
+
+# ---------------------------------------------------------------------------
+# Meeting parsing
+# ---------------------------------------------------------------------------
+
+YT_EMBED_RE = re.compile(r'youtube\.com/embed/([A-Za-z0-9_-]{6,})')
+YT_WATCH_RE = re.compile(r'(?:youtube\.com/watch\?v=|youtu\.be/)([A-Za-z0-9_-]{6,})')
+FATHOM_RE = re.compile(r'https?://[^)\s"]*fathom\.video[^)\s"]*')
+DATE_RE = re.compile(r'\*\*(?:Дата|Date)[:：]\*\*\s*([^\|\n]+)')
+MD_LINK_RE = re.compile(r'\[([^\]]+)\]\((https?://[^)\s]+)\)')
+BARE_URL_RE = re.compile(r'(?<![\(\["])\bhttps?://[^\s)<>"\]]+')
+
+# Acronyms (2-6 uppercase letters/digits) and TitleCase tech words.
+ACRONYM_RE = re.compile(r'\b[A-Z][A-Z0-9]{1,5}\b')
+
+
+def parse_meeting(path: Path):
+    """Parse one meeting MDX into a structured record. Returns None if unusable."""
+    try:
+        content = path.read_text(encoding='utf-8')
+    except OSError as e:
+        print(f"  ! cannot read {path}: {e}")
+        return None
+
+    fm, body = split_frontmatter(content)
+
+    lab_match = re.search(r'claude-code-internal-(\d+)', str(path))
+    lab = lab_match.group(1).zfill(2) if lab_match else "??"
+    number = path.stem.zfill(2) if path.stem.isdigit() else path.stem
+
+    title = str(fm.get('title', '')).strip()
+    description = str(fm.get('description', '')).strip()
+
+    yt_id = None
+    m = YT_EMBED_RE.search(body) or YT_WATCH_RE.search(body)
+    if m:
+        yt_id = m.group(1)
+
+    fathom = None
+    fm_match = FATHOM_RE.search(body)
+    if fm_match:
+        fathom = fm_match.group(0)
+
+    date = None
+    d = DATE_RE.search(body)
+    if d:
+        date = d.group(1).strip()
+
+    # Placeholder detection — frontmatter left unfilled by the pipeline.
+    placeholders = [p for p in ("[Название встречи]", "[Краткое описание встречи]",
+                                "[Дата встречи]") if p in content]
+
+    links = []
+    for label, url in MD_LINK_RE.findall(body):
+        links.append((label.strip(), url.strip()))
+    for url in BARE_URL_RE.findall(body):
+        links.append(("", url))
+
+    return {
+        "lab": lab,
+        "number": number,
+        "title": title,
+        "description": description,
+        "date": date,
+        "youtube_id": yt_id,
+        "fathom_url": fathom,
+        "placeholders": placeholders,
+        "links": links,
+        "body": body,
+        "path": str(path),
+        "url": f"https://{site_domain()}/claude-code-lab-{lab}/meetings/{number}",
+    }
+
+
+def collect_meetings():
+    site = docs_site_dir()
+    base = site / 'content' / 'docs'
+    if not base.exists():
+        print(f"FATAL: docs content dir not found: {base}")
+        print("Set DOCS_SITE_DIR in .env to your local agency-docs checkout.")
+        sys.exit(1)
+
+    meeting_files = sorted(base.glob('claude-code-internal-*/meetings/*.mdx'))
+    records = []
+    for f in meeting_files:
+        if not f.stem.isdigit():
+            continue  # skip index/meta pages
+        rec = parse_meeting(f)
+        if rec:
+            records.append(rec)
+    records.sort(key=lambda r: (r["lab"], r["number"]))
+    return records
+
+
+# ---------------------------------------------------------------------------
+# 1. Database (meetings index)
+# ---------------------------------------------------------------------------
+
+def build_database(records, dry_run):
+    page = out_path('AGG_DB_PAGE', 'content/docs/database.mdx')
+    data = out_path('AGG_DB_JSON', 'public/data/meetings.json')
+
+    rows = []
+    for r in records:
+        yt = f"[▶](https://youtu.be/{r['youtube_id']})" if r['youtube_id'] else "—"
+        fa = f"[Fathom]({r['fathom_url']})" if r['fathom_url'] else "—"
+        title = mdx_escape(r['title']) or "—"
+        rows.append(
+            f"| {r['lab']} | {r['number']} | {mdx_escape(r['date']) or '—'} "
+            f"| [{title}]({r['url']}) | {yt} | {fa} |"
+        )
+
+    mdx = (
+        "---\n"
+        'title: "База встреч"\n'
+        "description: Полный индекс всех встреч лаборатории Claude Code.\n"
+        "---\n\n"
+        "{/* GENERATED by agency-docs-updater/scripts/rebuild_aggregations.py — do not edit by hand. */}\n\n"
+        f"Всего встреч: **{len(records)}**. Обновлено: {datetime.now(timezone.utc):%Y-%m-%d}.\n\n"
+        "| Лаб | № | Дата | Встреча | Видео | Запись |\n"
+        "| --- | --- | --- | --- | --- | --- |\n"
+        + "\n".join(rows) + "\n"
+    )
+
+    json_payload = [
+        {k: r[k] for k in ("lab", "number", "title", "description", "date",
+                           "youtube_id", "fathom_url", "url")}
+        for r in records
+    ]
+
+    _write(page, mdx, dry_run)
+    _write(data, json.dumps(json_payload, ensure_ascii=False, indent=2), dry_run)
+    return [page, data]
+
+
+# ---------------------------------------------------------------------------
+# 2. Glossary (persisted term store + generated page)
+# ---------------------------------------------------------------------------
+
+def load_glossary_store():
+    store = out_path('AGG_GLOSSARY_STORE', '.agency-glossary.json')
+    if store.exists():
+        try:
+            return json.loads(store.read_text(encoding='utf-8')), store
+        except json.JSONDecodeError:
+            print(f"  ! glossary store is corrupt, starting fresh: {store}")
+    return {}, store
+
+
+def extract_terms(records):
+    """Return {term: set(meeting_urls)} of candidate technical terms."""
+    seen = defaultdict(set)
+    for r in records:
+        text = f"{r['title']} {r['description']} {r['body']}"
+        # Strip URLs first so referral codes / IDs inside links (e.g. .../r/GLEB3)
+        # don't get mistaken for acronyms.
+        text = re.sub(r'https?://\S+', ' ', text)
+        for term in ACRONYM_RE.findall(text):
+            seen[term].add(r['url'])
+        low = text.lower()
+        for phrase in KNOWN_PHRASES:
+            if phrase.lower() in low:
+                seen[phrase].add(r['url'])
+    # Drop trivial false positives.
+    noise = {"HTTP", "HTTPS", "HTML", "JSON", "URL", "ID", "OK", "PM", "AM", "TODO"}
+    return {t: u for t, u in seen.items() if t not in noise and len(u) >= 1}
+
+
+def build_glossary(records, dry_run):
+    store, store_path = load_glossary_store()
+    candidates = extract_terms(records)
+
+    # Merge: seed < persisted store; record mentions; flag new undefined terms.
+    new_terms = []
+    for term, urls in sorted(candidates.items()):
+        entry = store.get(term, {})
+        if "definition" not in entry:
+            seed_def = SEED_TERMS.get(term, "")
+            entry["definition"] = seed_def
+            if not seed_def:
+                new_terms.append(term)
+        entry["mentions"] = sorted(urls)
+        store[term] = entry
+
+    # Persist the store (so definitions survive and new terms can be filled in).
+    _write(store_path, json.dumps(store, ensure_ascii=False, indent=2), dry_run)
+
+    lines = []
+    for term in sorted(store, key=str.lower):
+        entry = store[term]
+        definition = mdx_escape(entry.get("definition", "")) or "_TODO: definition needed_"
+        mentions = entry.get("mentions", [])
+        ref = f" ({len(mentions)} встреч)" if mentions else ""
+        lines.append(f"### {mdx_escape(term)}\n\n{definition}{ref}\n")
+
+    mdx = (
+        "---\n"
+        'title: "Глоссарий"\n'
+        "description: Технические термины, встречающиеся в материалах лаборатории.\n"
+        "---\n\n"
+        "{/* GENERATED by agency-docs-updater/scripts/rebuild_aggregations.py — "
+        "edit definitions in .agency-glossary.json, not here. */}\n\n"
+        + "\n".join(lines) + "\n"
+    )
+    page = out_path('AGG_GLOSSARY_PAGE', 'content/docs/glossary.mdx')
+    _write(page, mdx, dry_run)
+
+    if new_terms:
+        print(f"  → {len(new_terms)} NEW term(s) need definitions: {', '.join(new_terms)}")
+        print(f"    Add definitions to: {store_path}")
+    return page, new_terms
+
+
+# ---------------------------------------------------------------------------
+# 3. Global library (all external links across meetings)
+# ---------------------------------------------------------------------------
+
+def build_library(records, dry_run):
+    # url -> {label, domain, mentions:set(meeting_url)}
+    by_url = {}
+    self_domain = site_domain()
+    # Per-meeting media (the Fathom recording and the YouTube video) already live
+    # in the database; the library is for genuine external resources, so skip them.
+    media_hosts = {"youtube.com", "youtu.be", "fathom.video"}
+    for r in records:
+        for label, url in r['links']:
+            host = urlparse(url).netloc.lower()
+            if host.startswith('www.'):
+                host = host[4:]
+            if not host or self_domain in host or host in media_hosts:
+                continue  # skip self-links and per-meeting video/recording links
+            item = by_url.setdefault(url, {"label": label, "domain": host, "mentions": set()})
+            if label and not item["label"]:
+                item["label"] = label
+            item["mentions"].add(r['url'])
+
+    by_domain = defaultdict(list)
+    for url, item in by_url.items():
+        by_domain[item["domain"]].append((url, item))
+
+    sections = []
+    for domain in sorted(by_domain):
+        sections.append(f"### {mdx_escape(domain)}\n")
+        for url, item in sorted(by_domain[domain], key=lambda x: x[0]):
+            label = mdx_escape(item["label"]) or url
+            n = len(item["mentions"])
+            sections.append(f"- [{label}]({url}){f' — {n} упоминаний' if n > 1 else ''}")
+        sections.append("")
+
+    mdx = (
+        "---\n"
+        'title: "Библиотека ресурсов"\n'
+        "description: Все внешние ссылки и ресурсы, упомянутые на встречах.\n"
+        "---\n\n"
+        "{/* GENERATED by agency-docs-updater/scripts/rebuild_aggregations.py — do not edit by hand. */}\n\n"
+        f"Всего ресурсов: **{len(by_url)}** из {len(by_domain)} источников.\n\n"
+        + "\n".join(sections) + "\n"
+    )
+    page = out_path('AGG_LIBRARY_PAGE', 'content/docs/library.mdx')
+    _write(page, mdx, dry_run)
+    return page
+
+
+# ---------------------------------------------------------------------------
+# Write helper
+# ---------------------------------------------------------------------------
+
+def _write(path: Path, content: str, dry_run: bool):
+    if dry_run:
+        print(f"  [dry-run] would write {path} ({len(content)} bytes)")
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding='utf-8')
+    print(f"  ✓ wrote {path} ({len(content)} bytes)")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    load_env()
+    ap = argparse.ArgumentParser(description="Rebuild agency-docs site-wide aggregations.")
+    ap.add_argument('--dry-run', action='store_true',
+                    help="Parse and report, but write nothing.")
+    ap.add_argument('--only', choices=['database', 'glossary', 'library'],
+                    help="Rebuild a single aggregation.")
+    args = ap.parse_args()
+
+    print(f"Scanning meetings under {docs_site_dir() / 'content' / 'docs'} ...")
+    records = collect_meetings()
+    print(f"Found {len(records)} meeting(s) across "
+          f"{len(set(r['lab'] for r in records))} lab(s).")
+
+    flagged = [r for r in records if r['placeholders'] or not r['youtube_id']]
+    if flagged:
+        print(f"⚠️  {len(flagged)} meeting(s) look incomplete "
+              f"(unfilled placeholders or missing video) — see the audit workflow:")
+        for r in flagged:
+            issues = []
+            if r['placeholders']:
+                issues.append("placeholders")
+            if not r['youtube_id']:
+                issues.append("no video")
+            print(f"    lab {r['lab']} #{r['number']}: {', '.join(issues)}")
+
+    written = []
+    if args.only in (None, 'database'):
+        print("Building database (meetings index)...")
+        written += build_database(records, args.dry_run)
+    if args.only in (None, 'glossary'):
+        print("Building glossary...")
+        page, new_terms = build_glossary(records, args.dry_run)
+        written.append(page)
+    if args.only in (None, 'library'):
+        print("Building global library...")
+        written.append(build_library(records, args.dry_run))
+
+    print(f"\nDone. {'Would write' if args.dry_run else 'Wrote'} {len(written)} file(s).")
+    if not args.dry_run:
+        print("Next: cd $DOCS_SITE_DIR && npm run build  (verify MDX compiles), then commit.")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## What

Three things for the `agency-docs-updater` skill, all on this branch:

### 1. Analysis — should the pipeline become a dynamic Workflow? (No)
`references/workflow-conversion-analysis.md`. The single-meeting publish pipeline is the anti-fit for the new Opus 4.8 dynamic-workflows feature: sequential, ~no fan-out, high public side effects, needs human-in-loop recovery. Keep it a Skill. The doc identifies the *real* workflow candidates instead — the fan-out maintenance jobs below.

### 2. Step 9 — rebuild site-wide aggregations after each meeting
`scripts/rebuild_aggregations.py`, wired into `SKILL.md` as Step 9. After each published meeting it regenerates, from **all** meetings:
- **database** — meetings index as `content/docs/database.mdx` + `public/data/meetings.json`
- **glossary** — `content/docs/glossary.mdx`; definitions persisted in `.agency-glossary.json` so human/LLM wording survives rebuilds, only genuinely new terms are flagged for definition
- **global library** — `content/docs/library.mdx`, deduplicated external links across all meetings (per-meeting video/recording links excluded — they're in the database)

Idempotent, `--dry-run`, `--only`, all I/O paths configurable via `AGG_*` env vars. Smoke-tested against a fixture (table render, JSON, glossary store merge, link dedup, placeholder/dead-embed flagging). Fixed three bugs found in testing: `lstrip('www.')` char-stripping, referral codes inside URLs leaking into the glossary, and media links leaking into the library.

### 3. Fan-out maintenance workflows
`references/workflows.md` — ready-to-run trigger prompts for two dynamic workflows:
- **`/agency-mdx-audit`** — one agent per meeting; checks MDX compile hazards, unfilled placeholders, dead YouTube embeds (oEmbed), dead links; cross-checked report, no edits.
- **`/agency-backfill`** — one agent per broken meeting; fixes only flagged issues, validates the build, leaves the tree dirty for manual review/commit.

Delivered as prompts (not committed `.js`) because dynamic workflows have no hand-authoring API — they're created by running and pressing `s` to save. Doc explains this and the preview/cost/no-mid-run-input caveats.

## Build context
Per the scoping Q&A: built against documented `${DOCS_SITE_DIR}` conventions for **local execution** (the agency-docs site isn't in this session). All output paths are configurable; run `rebuild_aggregations.py --dry-run` first to confirm paths against your real layout.

## Note / assumptions to confirm
- The three aggregation pages default to `content/docs/{database,glossary,library}.mdx`. If the site expects a different slug/nav (`meta.json`) layout, set the `AGG_*` env vars — no code change needed.
- Glossary term extraction is heuristic (acronyms + known phrases); skim the NEW-term list before defining.

https://claude.ai/code/session_01Kw51R3FQfKK3xuAbWMYbQt