### PR TITLE
Drop non-standard skill_file key from cognitive-toolkit

### DIFF
--- a/cognitive-toolkit/.claude-plugin/plugin.json
+++ b/cognitive-toolkit/.claude-plugin/plugin.json
@@ -22,6 +22,5 @@
     "obsidian",
     "pkm"
   ],
-  "skill_file": "skill.md",
   "license": "MIT"
 }


### PR DESCRIPTION
Removes `"skill_file": "skill.md"` from `cognitive-toolkit/.claude-plugin/plugin.json`.

- It pointed at lowercase `skill.md`, an alias of the canonical `SKILL.md` (same inode on case-insensitive macOS; a latent break on case-sensitive Linux/CI).
- `skill_file` isn't part of the plugin manifest schema and no other plugin in the repo uses it; standard `SKILL.md` discovery already covers it.

Safe cleanup — no change to how the skill loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)