### PR TITLE
Audit fixes for the cleanup skill: glob bug, privacy, setup mode, tests

### DIFF
--- a/skills/disk-cleanup/.gitignore
+++ b/skills/disk-cleanup/.gitignore
@@ -1,0 +1,5 @@
+# Personal/locale override — never commit (see config.local.example.json)
+config.local.json
+# Python bytecode
+__pycache__/
+*.pyc

--- a/skills/disk-cleanup/SKILL.md
+++ b/skills/disk-cleanup/SKILL.md
@@ -68,6 +68,26 @@ Keep installed software at `risk: never` (learned the hard way: `uv/tools`, `uv/
 `~/.rustup/toolchains`, `~/.bun`, `~/.deno` are NOT caches). Every non-advisory target's paths
 must resolve under `allowed_roots` or preflight will (correctly) refuse them.
 
+## Customization & setup (per-machine, never committed)
+
+`config.json` ships **generic, public-safe defaults**. Anything personal — names, family
+names, a non-English tax/legal/financial vocabulary — or machine-specific goes in
+**`config.local.json`** (gitignored). `load_config()` deep-merges it over `config.json`:
+**lists are unioned** (local terms only *add* protection to the Downloads exclude list), scalars
+override. See `config.local.example.json` for the shape.
+
+**Setup mode** — when the user first uses the skill, asks to personalize it, or has sensitive
+files in `~/Downloads`, offer to build `config.local.json` by asking (one short batch):
+1. Names/keywords in Downloads filenames that must **never** be swept (own name, family names).
+2. Their language's tax/legal/financial terms (e.g. German `steuer`, `rechnung`, `vertrag`).
+3. Their projects directory (for the `node_modules` sweep) and any extra app caches.
+Then write `config.local.json` (copy `config.local.example.json` and fill it in). Confirm what
+was saved. Never commit it.
+
+Per-machine paths in `targets.json` (`allowed_roots`, the `node-modules-projects` find root
+`~/ai_projects`) are examples — adjust them to the user's layout. Targets whose paths don't
+exist on this machine simply measure 0 and are skipped.
+
 ## Still agent-driven (only what genuinely can't be deterministic)
 
 - **Docker only** — surgical and stateful: survey with `docker images` / `docker ps -as` /

--- a/skills/disk-cleanup/config.json
+++ b/skills/disk-cleanup/config.json
@@ -9,32 +9,11 @@
     "age_days": 180,
     "min_mb": 0,
     "exclude_patterns": [
-      "genome",
-      "scheidung",
-      "kalinin",
-      "steuer",
-      "\\btax\\b",
-      "passport",
-      "visa",
-      "vertrag",
-      "contract",
-      "rechnung",
-      "invoice",
-      "\\bakt\\b",
-      "cert",
-      "\\.pem$",
-      "\\.pfx$",
-      "bank",
-      "insurance",
-      "versicherung",
-      "medical",
-      "health",
-      "legal",
-      "notar",
-      "bescheid",
-      "elster",
-      "__Organized"
+      "tax", "invoice", "receipt", "contract", "agreement",
+      "passport", "visa", "license", "\\bid\\b",
+      "cert", "\\.pem$", "\\.pfx$", "\\.key$",
+      "bank", "statement", "insurance", "medical", "health", "legal", "notary"
     ]
   },
-  "_doc": "preset: safe|full. min_size_mb hides trivia. downloads_scan drives the downloads-old target: only files older than age_days whose name does NOT match exclude_patterns (genome/legal/financial/personal stay forever). auto_empty_trash applies only with clean.py --go."
+  "_doc": "GENERIC, SHARED defaults — safe to commit publicly. preset: safe|full. min_size_mb hides trivia. downloads_scan drives the downloads-old target: only files older than age_days whose name does NOT match exclude_patterns are candidates (the dry-run lists them first). The exclude list here is deliberately broad/English. Personal names and locale-specific terms (e.g. another language's tax/legal vocabulary) belong in config.local.json — see config.local.example.json. config.local.json is gitignored and its lists are UNIONED on top of these, so local terms only ADD protection. auto_empty_trash applies only with clean.py --go."
 }

--- a/skills/disk-cleanup/config.local.example.json
+++ b/skills/disk-cleanup/config.local.example.json
@@ -1,0 +1,10 @@
+{
+  "_doc": "Copy this to config.local.json (gitignored, never committed) to extend the shared config with PERSONAL and LOCALE-specific terms. Lists are UNIONED with config.json (additive — these only add protection); scalars override. Replace the examples below with your own names, family names, and your language's tax/legal/financial vocabulary so those Downloads files are never swept.",
+  "downloads_scan": {
+    "exclude_patterns": [
+      "yourname", "familyname",
+      "steuer", "rechnung", "vertrag", "versicherung", "notar", "bescheid", "elster",
+      "genome", "passport-scan"
+    ]
+  }
+}

--- a/skills/disk-cleanup/scripts/clean.py
+++ b/skills/disk-cleanup/scripts/clean.py
@@ -17,9 +17,11 @@ Safety (per audit):
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))  # import lib regardless of CWD
 import lib
 
 
@@ -157,5 +159,4 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.path.insert(0, str(lib.HERE))
     main()

--- a/skills/disk-cleanup/scripts/lib.py
+++ b/skills/disk-cleanup/scripts/lib.py
@@ -22,6 +22,31 @@ def load_json(name: str) -> dict:
     return json.loads((SKILL_DIR / name).read_text(encoding="utf-8"))
 
 
+def _deep_merge(base: dict, over: dict) -> None:
+    """Recursive merge: dicts recurse, lists union (base order first), scalars override."""
+    for k, v in over.items():
+        if isinstance(v, dict) and isinstance(base.get(k), dict):
+            _deep_merge(base[k], v)
+        elif isinstance(v, list) and isinstance(base.get(k), list):
+            base[k] = base[k] + [x for x in v if x not in base[k]]
+        else:
+            base[k] = v
+
+
+def load_config() -> dict:
+    """config.json with an optional gitignored config.local.json deep-merged over it, so a
+    user can add personal/locale exclude terms and machine-specific settings without touching
+    the shared, committed config. Lists are UNIONED (additive — local terms add protection)."""
+    cfg = load_json("config.json")
+    local = SKILL_DIR / "config.local.json"
+    if local.exists():
+        try:
+            _deep_merge(cfg, json.loads(local.read_text(encoding="utf-8")))
+        except json.JSONDecodeError:
+            pass  # malformed local override → fall back to committed config, don't crash
+    return cfg
+
+
 def expand(p: str) -> Path:
     """Expand ~ and env vars; do NOT resolve symlinks yet (preflight does that)."""
     return Path(os.path.expandvars(os.path.expanduser(p)))
@@ -105,6 +130,7 @@ def find_dirs(root: str, name: str, maxdepth: int, min_mb: int) -> list[Path]:
                 p = Path(dirpath) / d
                 if du_bytes(p) >= min_mb * 1024 * 1024:
                     hits.append(p)
+                dirnames.remove(d)  # don't descend into a match (no nested re-match / double-count)
     return sorted(hits, key=lambda x: str(x))
 
 
@@ -168,18 +194,26 @@ def resolve_target_paths(target: dict) -> list[Path]:
         f = target["find"]
         out = find_dirs(f["root"], f["name"], f.get("maxdepth", 4), f.get("min_mb", 50))
     elif method == "downloads-scan":
-        out = scan_downloads(load_json("config.json").get("downloads_scan", {}))
+        out = scan_downloads(load_config().get("downloads_scan", {}))
     elif method == "simctl":
         return []  # action, not paths
     else:
+        import glob as _glob
         for p in target.get("paths", []):
             ep = expand(p)
             if "*" in p or "?" in p:
-                out.extend(sorted(ep.parent.glob(ep.name)))
+                # stdlib glob handles wildcards at ANY depth (e.g. /private/var/folders/*/*/C/clang);
+                # Path.parent.glob(name) only globs the last component and silently missed mid-path *.
+                out.extend(Path(m) for m in sorted(_glob.glob(str(ep))))
             elif ep.exists():
                 out.append(ep)
-    # dedupe by canonical path, drop nested overlaps, deterministic order
+    # dedupe by canonical path, then drop any path nested under another already kept (no double-count)
     seen: dict[str, Path] = {}
     for p in out:
         seen[str(canonical(p))] = p
-    return [seen[k] for k in sorted(seen)]
+    kept: list[str] = []
+    for c in sorted(seen):  # parents sort before children, so a kept parent absorbs its children
+        if any(c == k or c.startswith(k + "/") for k in kept):
+            continue
+        kept.append(c)
+    return [seen[c] for c in kept]

--- a/skills/disk-cleanup/scripts/survey.py
+++ b/skills/disk-cleanup/scripts/survey.py
@@ -10,8 +10,10 @@ Sizes are APPROXIMATE (du block counts on APFS). Output is deterministically sor
 
 import argparse
 import json
+import os
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))  # import lib regardless of CWD
 import lib
 
 
@@ -61,7 +63,7 @@ def discover(reg: dict, min_mb: int) -> list[dict]:
 
 def build(args) -> dict:
     reg = lib.load_json("targets.json")
-    cfg = lib.load_json("config.json")["defaults"]
+    cfg = lib.load_config()["defaults"]
     min_mb = args.min_mb or cfg.get("min_size_mb", 10)
     rows = measure_targets(reg)
     totals = {}
@@ -111,5 +113,4 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.path.insert(0, str(lib.HERE))
     main()

--- a/skills/disk-cleanup/scripts/tests/test_safety.py
+++ b/skills/disk-cleanup/scripts/tests/test_safety.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Safety-core tests for disk-cleanup. Stdlib unittest only (no deps).
+
+Run:  python3 scripts/tests/test_safety.py
+"""
+
+import os
+import sys
+import time
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import lib  # noqa: E402
+
+
+class Preflight(unittest.TestCase):
+    def test_refuses_outside_allowed_roots(self):
+        with tempfile.TemporaryDirectory() as d:
+            ok, _ = lib.preflight(Path(d), ["~/Library"])  # tmp is not under ~/Library
+            self.assertFalse(ok)
+
+    def test_allows_dir_under_allowed_root(self):
+        with tempfile.TemporaryDirectory() as d:
+            sub = Path(d) / "cache"
+            sub.mkdir()
+            ok, reason = lib.preflight(sub, [d])
+            self.assertTrue(ok, reason)
+
+    def test_refuses_symlink(self):
+        with tempfile.TemporaryDirectory() as d:
+            target = Path(d) / "real"
+            target.mkdir()
+            link = Path(d) / "link"
+            link.symlink_to(target)
+            ok, _ = lib.preflight(link, [d])
+            self.assertFalse(ok)
+
+    def test_refuses_home_even_if_allowed(self):
+        ok, reason = lib.preflight(Path("~"), ["~"])
+        self.assertFalse(ok)
+        self.assertIn("HOME", reason)
+
+
+class DownloadsScan(unittest.TestCase):
+    def test_excludes_sensitive_and_keeps_old_junk(self):
+        with tempfile.TemporaryDirectory() as d:
+            keep_out = Path(d) / "tax_return_2020.pdf"   # matches exclude → must NOT be returned
+            sweep = Path(d) / "old_installer.dmg"        # no match, old → must be returned
+            for f in (keep_out, sweep):
+                f.write_text("x")
+            old = time.time() - 400 * 86400
+            for f in (keep_out, sweep):
+                os.utime(f, (old, old))
+            res = {p.name for p in lib.scan_downloads(
+                {"root": d, "age_days": 180, "min_mb": 0, "exclude_patterns": ["tax"]})}
+            self.assertIn("old_installer.dmg", res)
+            self.assertNotIn("tax_return_2020.pdf", res)
+
+    def test_skips_recent_files(self):
+        with tempfile.TemporaryDirectory() as d:
+            recent = Path(d) / "fresh.zip"
+            recent.write_text("x")  # mtime = now
+            res = lib.scan_downloads(
+                {"root": d, "age_days": 180, "min_mb": 0, "exclude_patterns": []})
+            self.assertEqual(res, [])
+
+
+class GlobResolution(unittest.TestCase):
+    def test_midpath_wildcard_resolves(self):
+        # regression: parent.glob(name) missed mid-path '*'; glob.glob must find it.
+        with tempfile.TemporaryDirectory() as d:
+            deep = Path(d) / "aa" / "bb" / "C"
+            deep.mkdir(parents=True)
+            (deep / "clang").mkdir()
+            target = {"method": "trash", "paths": [str(Path(d) / "*" / "*" / "C" / "clang")]}
+            res = lib.resolve_target_paths(target)
+            self.assertEqual([p.name for p in res], ["clang"])
+
+    def test_nested_overlap_dropped(self):
+        with tempfile.TemporaryDirectory() as d:
+            outer = Path(d) / "node_modules"
+            inner = outer / "pkg" / "node_modules"
+            inner.mkdir(parents=True)
+            target = {"method": "trash", "paths": [str(outer), str(inner)]}
+            res = [str(p) for p in lib.resolve_target_paths(target)]
+            self.assertEqual(res, [str(outer)])  # inner absorbed by its parent
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Findings from a skill-creator audit, applied:

- **P0 bug:** mid-path wildcards never resolved (only the last path component was globbed), so the clang temp-cache target was silently dead. Now uses stdlib glob — verified it finds the real path.
- **find_dirs / resolve:** prune matched dirs and drop nested overlaps so nested node_modules aren't double-counted or trashed twice (the 'drop nested overlaps' comment is now true).
- **Privacy/portability:** the committed config carried personal + locale-specific Downloads exclude terms (names, tax/legal vocab) in a public repo. Now ships generic public-safe defaults; personal/locale terms move to a gitignored config.local.json (deep-merged, lists unioned), with an example file and a SKILL.md setup-mode flow.
- **Robust imports + dead-code removal**, and a new stdlib test suite (8 tests) locking in the safety core.

All scripts compile; tests pass; survey + dry-run verified non-destructive.

Generated with Claude Code.