### PR TITLE
Add modular Cull release skill suite

### DIFF
--- a/cull-release-check/SKILL.md
+++ b/cull-release-check/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: cull-release-check
+description: Use when assessing whether Cull is ready to release, auditing or dry-running a Cull release, identifying version blockers, or before any Cull prepare or publish operation.
+---
+
+# Cull Release Check
+
+## Principle
+
+Treat Cull's JSON release CLI as authoritative. This skill is strictly read-only.
+
+## Run the check
+
+1. Resolve the checkout: current Git repository when its origin matches
+   `glebis/cull`; otherwise absolute `CULL_REPO`; otherwise
+   `$HOME/ai_projects/cull`.
+2. Require an explicit `patch|minor|major` only when calculating a new target.
+   Otherwise inspect the current candidate.
+3. Capture `git status --porcelain` and `git rev-parse HEAD`.
+4. Run `npm run release:cull -- check --bump "$KIND" --json` from the checkout.
+5. Parse exactly one JSON envelope from stdout. Treat extra stdout, invalid JSON,
+   or a nonzero exit as a blocker.
+6. Capture status and HEAD again. If either changed, return
+   `CHECK_MUTATED_REPOSITORY` and stop.
+
+## Report contract
+
+Report current and target versions, source SHA, branch and sync state, disk,
+toolchains, contract gates, CI, secret presence, and every blocker. Report secret
+presence only; never print environment values or secret contents.
+
+## Mutation boundary
+
+Run no preparation, commit, tag, push, workflow dispatch, publication, Homebrew
+promotion, installation, or recovery apply action. If the CLI proposes one,
+report it without executing it.

--- a/cull-release-check/agents/openai.yaml
+++ b/cull-release-check/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Cull Release Check"
+  short_description: "Audit Cull release readiness safely"
+  default_prompt: "Use $cull-release-check to report every release blocker without changing the repository."
+policy:
+  allow_implicit_invocation: true

--- a/cull-release-prepare/SKILL.md
+++ b/cull-release-prepare/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: cull-release-prepare
+description: Use when the user explicitly asks to prepare or bump a Cull patch, minor, or major release, curate its changelog and compatibility review, or create its focused release commit without publishing.
+---
+
+# Cull Release Prepare
+
+## Principle
+
+Prepare one reproducible release commit.
+
+Preparation cannot tag, push, dispatch workflows, publish, or update Homebrew.
+
+## Required inputs
+
+- An explicit `patch|minor|major`; never infer the bump.
+- Green cull-release-check evidence bound to `expectedSource` and
+  `expectedVersion`.
+- Curated release notes and compatibility-review JSON matching Cull's CLI schema.
+
+## Prepare
+
+1. Fetch `origin/main` and create a dedicated clean worktree from it. Preserve
+   unrelated dirty worktrees.
+2. Confirm the check evidence still matches HEAD and the expected next version.
+3. Store curated notes in a safely quoted path. Use argument arrays or separately
+   quoted variables; never evaluate a concatenated command.
+4. Run the dry run first: `npm run release:cull -- prepare ... --dry-run --json`.
+5. Parse exactly one JSON envelope. Continue only when it lists exactly the
+   configured version, changelog, compatibility, and state files.
+6. Run the same prepare command without `--dry-run`.
+7. Verify one `chore(release): vX.Y.Z` commit, state `prepared`, the declared file
+   set, no tag, and no remote mutation.
+
+On failure, show diagnostics and changed files. Never reset, discard, or overwrite
+work outside the release-owned file set.

--- a/cull-release-prepare/agents/openai.yaml
+++ b/cull-release-prepare/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Cull Release Prepare"
+  short_description: "Prepare Cull release metadata and commit"
+  default_prompt: "Use $cull-release-prepare to prepare a Cull patch release without tagging or pushing."
+policy:
+  allow_implicit_invocation: false

--- a/cull-release-publish/SKILL.md
+++ b/cull-release-publish/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: cull-release-publish
+description: Use when the user explicitly asks to publish or complete a prepared Cull release, or when the authorized cull-release orchestrator reaches publication after every repository and artifact gate passes.
+---
+
+# Cull Release Publish
+
+## Authority
+
+An explicit “Release Cull patch|minor|major” or direct “Publish prepared Cull
+release X.Y.Z” request authorizes publication. Do not ask for another confirmation
+after gates pass. That authority does not waive or bypass any gate.
+
+Implicit invocation is disabled. Without that explicit authority, stop before any
+tag, push, workflow dispatch, release, or tap mutation.
+
+## Publish
+
+1. Resolve the Cull checkout and parse one JSON envelope from
+   `npm run release:cull -- state show --version "$VERSION" --json`.
+2. Require state `prepared`, exact metadata, a clean release commit already pushed
+   on `main`, green required checks, active branch/tag protection, publication
+   enablement, and no conflicting tag.
+3. Create one annotated tag for the prepared commit and push that tag normally.
+   Never move, replace, or force-push a tag.
+4. Watch the tag-bound GitHub release workflow. Never substitute a local build.
+5. Require the secret-free verifier's exact artifact inventory, signatures,
+   notarization, checksums, and provenance before automatic publication.
+6. Wait for checksum-pinned Homebrew promotion and its audit/install/launch proof.
+7. Record evidence transitions through `published` and `homebrew-promoted` using
+   the repository CLI's state commands.
+
+On failure, use cull-release-recover. Never delete or rewrite a tag, delete a
+release, replace published assets, bypass verification, or force workflow state.

--- a/cull-release-publish/agents/openai.yaml
+++ b/cull-release-publish/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Cull Release Publish"
+  short_description: "Publish verified Cull release artifacts"
+  default_prompt: "Use $cull-release-publish to publish an already prepared Cull release through verified distribution."
+policy:
+  allow_implicit_invocation: false

--- a/cull-release-recover/SKILL.md
+++ b/cull-release-recover/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: cull-release-recover
+description: Use when a Cull release is stuck, inconsistent, failed in a workflow or artifact gate, missing Homebrew promotion, failed after publication, or needs a safe recovery or patch plan.
+---
+
+# Cull Release Recover
+
+## Principle
+
+Derive truth from external evidence, then resume the first incomplete safe phase.
+Never erase immutable release history to make local state look consistent.
+
+## Diagnose
+
+1. Resolve the Cull checkout.
+2. Run `npm run release:cull -- resume --version "$VERSION" --json` and parse
+   exactly one JSON envelope. Treat local release state as a cache.
+3. Authenticate and compare the prepared commit, remote annotated tag and peeled
+   commit, Actions run, exact asset inventory, public release, updater metadata,
+   provenance, and Homebrew cask/evidence.
+4. Classify the next action exactly as `rerun-check`, `prepare-new-version`,
+   `watch-build`, `verify-artifact`, `publish-verified-artifacts`,
+   `promote-homebrew`, or `prepare-patch-plan`.
+5. Execute only the safe resumable phase the user already authorized. Do not
+   repeat a completed signed build or replace verified artifacts.
+
+A post-publish verification failure creates or updates the stable P0 bd incident,
+blocks later release checks, and returns `prepare-patch-plan`. Prepare the patch
+plan but never publish that patch implicitly.
+
+Never delete or move a tag or release. Never force-push, clobber assets, reset
+unrelated work, bypass a gate, clean `cull.db`, or treat missing evidence as
+success.

--- a/cull-release-recover/agents/openai.yaml
+++ b/cull-release-recover/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Cull Release Recover"
+  short_description: "Recover a failed Cull release safely"
+  default_prompt: "Use $cull-release-recover to diagnose a failed Cull release and prepare the safest resumable action."
+policy:
+  allow_implicit_invocation: false

--- a/cull-release-verify/SKILL.md
+++ b/cull-release-verify/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: cull-release-verify
+description: Use when verifying or auditing a Cull release, DMG, updater archive, notarization, Homebrew cask, installed version, launch health, or post-publication distribution state.
+---
+
+# Cull Release Verify
+
+## Principle
+
+Reconstruct release truth from immutable public evidence. Verification is
+read-only by default.
+
+## Verify
+
+1. Resolve the Cull checkout and select the explicit version or latest public
+   release.
+2. Run `npm run release:cull -- state show --version "$VERSION" --json` and parse
+   exactly one JSON envelope.
+3. Bind the annotated Git tag object and peeled commit to the published release,
+   authenticated workflow run, provenance, and required asset inventory.
+4. Download artifacts to an isolated temporary directory. Run Cull's exact
+   artifact verifier; check updater signature, SHA-256 checksums, DMG contents,
+   embedded version and architecture, codesign, Gatekeeper, and notarization
+   staple.
+5. Compare Homebrew version and SHA-256 with public provenance and require its
+   promotion evidence.
+6. Report version, commit, tag object, workflow, asset hashes, release URL, tap
+   commit, installed-version evidence, launch evidence, and mismatches.
+
+Default to no installation. When the user explicitly requests an install smoke,
+use an isolated location and preserve any existing app. Never edit release state,
+the GitHub release, tags, the tap, system Applications, or `cull.db`.

--- a/cull-release-verify/agents/openai.yaml
+++ b/cull-release-verify/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Cull Release Verify"
+  short_description: "Verify Cull artifacts and distribution"
+  default_prompt: "Use $cull-release-verify to verify a Cull release and all distribution channels."
+policy:
+  allow_implicit_invocation: true

--- a/cull-release/SKILL.md
+++ b/cull-release/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: cull-release
+description: Use when orchestrating or resuming Cull's complete release cycle, reporting its current release state, or fulfilling an explicit Cull patch, minor, or major release request through verified GitHub and Homebrew distribution.
+---
+
+# Cull Release
+
+## Principle
+
+Orchestrate Cull's repository-enforced phases; never recreate release logic in
+the skill. Read `references/phase-contracts.md` before acting.
+
+## Start or resume
+
+1. Resolve Cull from a matching current origin, absolute `CULL_REPO`, or
+   `$HOME/ai_projects/cull`.
+2. For a new release, require explicit `patch|minor|major`; never infer it.
+3. Use cull-release-check. Stop on every blocker.
+4. Use cull-release-prepare in its isolated worktree.
+5. Use cull-release-publish after preparation. An explicit complete-release
+   request already authorizes publication: Do not ask for a second publication confirmation.
+6. Use cull-release-verify after GitHub publication and Homebrew promotion.
+7. On interruption, derive the last verified state from commit, tag, workflow,
+   artifacts, release, and tap evidence. Resume the first incomplete phase; do
+   not repeat completed work.
+8. Route every mismatch or failed phase through cull-release-recover.
+
+## Completion report
+
+Report version, release commit, annotated tag object, workflow run, artifact
+hashes, release URL, Homebrew tap commit, and final
+`post-publish-verified` state. Do not print secret values.

--- a/cull-release/agents/openai.yaml
+++ b/cull-release/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Cull Release"
+  short_description: "Orchestrate Cull's guarded release cycle"
+  default_prompt: "Use $cull-release to release Cull safely from checks through verification."
+policy:
+  allow_implicit_invocation: false

--- a/cull-release/references/phase-contracts.md
+++ b/cull-release/references/phase-contracts.md
@@ -1,0 +1,30 @@
+# Cull release phase contracts
+
+## Runtime
+
+Resolve Cull from the current repository when origin matches `glebis/cull`, then
+absolute `CULL_REPO`, then `$HOME/ai_projects/cull`. Require
+`npm run release:cull -- --help`. Parse exactly one JSON envelope from stdout;
+stderr is operator logging. Exit codes: `2` input/config, `3` blocked gate, `4`
+external action failure, `5` inconsistent or recovery-required state.
+
+An explicit “Release Cull patch|minor|major” request authorizes the full cycle,
+including publication after all gates. It never authorizes bypassing a gate.
+
+## States
+
+| Accepted state | Phase and command | Required evidence | Legal next state | Mutation boundary | Failure route |
+| --- | --- | --- | --- | --- | --- |
+| `requested` | Check: `npm run release:cull -- check --bump KIND --json` | version, source SHA, sync, disk, toolchains, gates | `checked` | none | `rerun-check` |
+| `checked` | Prepare: `npm run release:cull -- prepare ... --dry-run --json`, then real prepare | bound plan, notes, compatibility review, release commit | `prepared` | release-owned files and one commit | `prepare-new-version` |
+| `prepared` | Publish preflight and one annotated-tag push | pushed main commit, exact version, tag object | `tagged` | one new tag | `prepare-new-version` |
+| `tagged` | Watch tag-bound Release workflow | authenticated run and signed inventory | `draft-built` | workflow-owned empty draft only after verification | `watch-build` |
+| `draft-built` | Secret-free exact artifact verification | updater signature, notarization, inventory, SHA-256, gate evidence | `artifact-verified` | no public mutation | `verify-artifact` |
+| `artifact-verified` | Guarded workflow publication | public digest equality, provenance, immutable tag | `published` | publish exact verified assets | `publish-verified-artifacts` |
+| `published` | Provenance-bound Homebrew workflow | public provenance, exact DMG SHA-256, audit/install/launch | `homebrew-promoted` | one cask commit or idempotent no-op | `promote-homebrew` |
+| `homebrew-promoted` | cull-release-verify | release, updater, trust, cask, install/launch evidence | `post-publish-verified` | none by default | `prepare-patch-plan` |
+| `post-publish-verified` | Report complete | all prior immutable evidence | terminal | none | `prepare-patch-plan` if later evidence fails |
+
+Local `.release-state/<version>.json` is a resumability cache. Re-derive state
+from external evidence before advancing. Never delete or rewrite a tag/release,
+clobber assets, force-push, or silently publish a recovery patch.

--- a/cull-release/scripts/install-suite.sh
+++ b/cull-release/scripts/install-suite.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+skills=(cull-release cull-release-check cull-release-prepare cull-release-publish cull-release-verify cull-release-recover)
+source_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+target_root=${AGENT_SKILLS_DIR:-$HOME/.agents/skills}
+mkdir -p "$target_root"
+
+for skill in "${skills[@]}"; do
+  source_path="$source_root/$skill"
+  target_path="$target_root/$skill"
+  if [[ ! -d "$source_path" ]]; then
+    echo "missing suite skill: $source_path" >&2
+    exit 2
+  fi
+  if [[ -L "$target_path" && "$(readlink "$target_path")" == "$source_path" ]]; then
+    continue
+  fi
+  if [[ -e "$target_path" || -L "$target_path" ]]; then
+    echo "refusing to replace existing skill path: $target_path" >&2
+    exit 2
+  fi
+  ln -s "$source_path" "$target_path"
+done

--- a/cull-release/scripts/install-suite.test.sh
+++ b/cull-release/scripts/install-suite.test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+installer="$script_dir/install-suite.sh"
+source_root=$(cd "$script_dir/../.." && pwd)
+tmp=$(mktemp -d)
+trap 'trash "$tmp"' EXIT
+skills=(cull-release cull-release-check cull-release-prepare cull-release-publish cull-release-verify cull-release-recover)
+
+created="$tmp/created"
+AGENT_SKILLS_DIR="$created" bash "$installer"
+for skill in "${skills[@]}"; do
+  test -L "$created/$skill"
+  test "$(readlink "$created/$skill")" = "$source_root/$skill"
+done
+AGENT_SKILLS_DIR="$created" bash "$installer"
+
+wrong="$tmp/wrong"
+mkdir -p "$wrong"
+ln -s "$tmp/not-the-suite" "$wrong/cull-release"
+if AGENT_SKILLS_DIR="$wrong" bash "$installer"; then
+  echo "installer replaced or accepted a wrong symlink" >&2
+  exit 1
+fi
+test "$(readlink "$wrong/cull-release")" = "$tmp/not-the-suite"
+
+directory="$tmp/directory"
+mkdir -p "$directory/cull-release"
+if AGENT_SKILLS_DIR="$directory" bash "$installer"; then
+  echo "installer replaced or accepted a real directory" >&2
+  exit 1
+fi
+test -d "$directory/cull-release"
+
+echo "install-suite tests passed"

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -11,6 +11,9 @@ description: >-
 
 # release — tiered compatibility & release workflow
 
+For the Cull repository, use `$cull-release`; Cull's repository-enforced state,
+artifact, updater, and Homebrew gates are stricter than this generic workflow.
+
 A config-driven release orchestrator. Mechanics live in `scripts/release.py`
 (unit-tested, stdlib-only); this file is the workflow you (or an agent) follow.
 Read `reference/config-schema.md` for `release.config.json` and


### PR DESCRIPTION
## Summary
- add explicit Cull release coordinator plus check, prepare, publish, verify, and recover phase skills
- keep mutating skills explicit-only and preserve repository-enforced gates
- add idempotent discovery installer that refuses conflicting paths
- route the generic release skill to Cull-specific safeguards

## Verification
- all six skill-creator validations pass
- all six baseline-to-green content contracts pass
- installer create/idempotent/wrong-symlink/real-directory tests pass
- no production release or tap API was used during skill testing